### PR TITLE
Internal repr

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -322,6 +322,33 @@ files = [
 colors = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "jsonpatch"
+version = "1.33"
+description = "Apply JSON-Patches (RFC 6902)"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
+files = [
+    {file = "jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade"},
+    {file = "jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c"},
+]
+
+[package.dependencies]
+jsonpointer = ">=1.9"
+
+[[package]]
+name = "jsonpointer"
+version = "2.4"
+description = "Identify specific nodes in a JSON document (RFC 6901)"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
+files = [
+    {file = "jsonpointer-2.4-py2.py3-none-any.whl", hash = "sha256:15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"},
+    {file = "jsonpointer-2.4.tar.gz", hash = "sha256:585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"},
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.22.0"
 description = "An implementation of JSON Schema validation for Python"
@@ -1171,6 +1198,18 @@ files = [
 ]
 
 [[package]]
+name = "toolz"
+version = "0.12.1"
+description = "List processing tools and functional utilities"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "toolz-0.12.1-py3-none-any.whl", hash = "sha256:d22731364c07d72eea0a0ad45bafb2c2937ab6fd38a3507bf55eae8744aa7d85"},
+    {file = "toolz-0.12.1.tar.gz", hash = "sha256:ecca342664893f177a13dac0e6b41cbd8ac25a358e5f215316d43e2100224f4d"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.11.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -1211,6 +1250,22 @@ brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "warlock"
+version = "2.0.1"
+description = "Python object model built on JSON schema and JSON patch."
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "warlock-2.0.1-py3-none-any.whl", hash = "sha256:448df959cec31904f686ac8c6b1dfab80f0cdabce3d303be517dd433eeebf012"},
+    {file = "warlock-2.0.1.tar.gz", hash = "sha256:99abbf9525b2a77f2cde896d3a9f18a5b4590db063db65e08207694d2e0137fc"},
+]
+
+[package.dependencies]
+jsonpatch = ">=1,<2"
+jsonschema = ">=4,<5"
 
 [[package]]
 name = "wrapt"
@@ -1295,4 +1350,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "b39905b6d395cf06517c8e88a8b02a269a08e4cf1d08218425a6a5ab325c05c0"
+content-hash = "014dae40385d179568c8f3242cbc13a1394cff3a53b3836a4ae2ec410a36b8af"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ coverage = "^7.5.0"
 matplotlib = "^3.8.3"
 numpy = "^1.26.4"
 rich = "^13.7.1"
+warlock = "^2.0.1"
+toolz = "^0.12.1"
 
 [tool.poetry.group.dev.dependencies]
 pylint = "^2.17.5"

--- a/src/mdframe/analysis.py
+++ b/src/mdframe/analysis.py
@@ -15,7 +15,7 @@ def flatten_property_dict(property_dict: Dict) -> Dict:
     return flattened_dict
 
 
-def load_flattened_data(config):
+def load_flattened_data(config: Config) -> pd.DataFrame:
     """
     Loads and flattens data based on the given configuration.
 
@@ -30,15 +30,13 @@ def load_flattened_data(config):
     """
     entries = run(config)
     
-    # convert all pandas Series objects into dictionaries, and flatten them in order to isolate property_name
-    entries = [pd.Series.to_dict(entry) for entry in entries]
     entries = [flatten_property_dict(entry) for entry in entries]
 
     df = pd.DataFrame(entries)
     return df
 
 
-def filter_data(config, query, filename):
+def filter_data(config: Config, query: str, filename: str):
     """
     Filters data from a DataFrame based on a given query and saves the result to a CSV file.
 
@@ -60,14 +58,13 @@ def filter_data(config, query, filename):
     # df = df.query(query)
 
     df = df[eval(query)]
-    # print(df)
 
     df.to_csv(filename)
 
 
 # TODO: augment generate_histogram to use load_data function
 # TODO: have generate_histogram use global flatten_property_dict method
-def generate_histogram(config, property_name='quality', data_type='discrete'):
+def generate_histogram(config: Config, property_name: str ='quality', data_type: str = 'discrete'):
     """Generates a histogram based on the given configuration, property name, and data type.
 
     Args:
@@ -127,7 +124,7 @@ def generate_histogram(config, property_name='quality', data_type='discrete'):
 
 if __name__ == '__main__':
     config = Config(
-        data_path=Path(__file__).parent / "data", 
+        metadata_file_paths=Path(__file__).parent / "data", 
         metadata_file_extension="toml",
         schema_loc=Path('schema.json')
     )

--- a/test/test_analysis.py
+++ b/test/test_analysis.py
@@ -1,5 +1,6 @@
 import unittest
 from pathlib import Path
+from typing import Tuple
 from mdframe.reader import run, Config
 from mdframe.analysis import flatten_property_dict, load_flattened_data, filter_data, generate_histogram
 import pandas as pd
@@ -13,38 +14,35 @@ class TestAnalysis(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.schema_loc = root / "../src/mdframe/schema.json"
+        cls.test_data_path = Path(__file__).parent / "data"
+        cls.flattened_data_path = Path(__file__).parent / "flattened_data"
+        cls.filtered_data_filename = 'filtered_data.csv'
+        cls.filtered_data_file_path = Path(__file__).parent / cls.filtered_data_filename
+        cls.representation = "raw"
+
+    def flatten_property_dict_test_factory(self, file_idx: int):
+        input_file = self.test_data_path / f"{file_idx:02}_input_file.toml"
+        output_file = self.flattened_data_path / f"{file_idx:02}_flattened_file.toml"
+        with open(input_file, 'r') as f:
+            input_file = toml.load(f)
+        with open(output_file, 'r') as f:
+            output_file = toml.load(f)
+        self.assertDictEqual(flatten_property_dict(input_file), output_file)
+
 
     def test_flatten_property_dict(self):
-        test_data_path = Path(__file__).parent / "data"
-        flattened_data_path = Path(__file__).parent / "flattened_data"
+        for i in range(0, 2):
+            with self.subTest(i=i):
+                self.flatten_property_dict_test_factory(i)
 
-        # first test
-        with open(test_data_path / "00_input_file.toml", 'r') as f:
-            input_file_0 = toml.load(f)
-        with open(flattened_data_path / "00_flattened_file.toml", 'r') as f:
-            output_file_0 = toml.load(f)
-        assert flatten_property_dict(input_file_0) == output_file_0
 
-        # second test
-        with open(test_data_path / "01_input_file.toml", 'r') as f:
-            input_file_1 = toml.load(f)
-        with open(flattened_data_path / "01_flattened_file.toml", 'r') as f:
-            output_file_1 = toml.load(f)
-        assert flatten_property_dict(input_file_1) == output_file_1
-        
-        # third test
-        with open(test_data_path / "02_input_file.toml", 'r') as f:
-            input_file_2 = toml.load(f)
-        with open(flattened_data_path / "02_flattened_file.toml", 'r') as f:
-            output_file_2 = toml.load(f)
-        assert flatten_property_dict(input_file_2) == output_file_2
-
-    @unittest.skip("")
+    @unittest.skip("This test is failing, needs to be fixed.")
     def test_load_flatten_data(self):
         config = Config(
-            data_path=Path(__file__).parent / "data", 
+            metadata_file_paths=self.test_data_path, 
             metadata_file_extension="toml", 
-            schema_loc=self.schema_loc
+            schema_loc=self.schema_loc,
+            representation=self.representation
         )
 
         # create a dataframe using the method
@@ -53,46 +51,54 @@ class TestAnalysis(unittest.TestCase):
         # create an identical dataframe by manually accessing the equivalent flattened_data files
         flattened_data_path = Path(__file__).parent / "flattened_data"
         files = []
-        for file in list(flattened_data_path.iterdir()):
+        for file in flattened_data_path.iterdir():
             with open(flattened_data_path / file, 'r') as f:
                 files.append(toml.load(f))
         second_df = pd.DataFrame.from_dict(files)
 
         assert first_df.equals(second_df)
 
-    def test_filter_data(self):
-        filtered_data_filename = 'filtered_data.csv'
-        filtered_data_file_path = Path(__file__).parent / filtered_data_filename
+    def delete_filtered_data_file(self):
+        if self.filtered_data_file_path.exists():
+            self.filtered_data_file_path.unlink()
 
+    def filter_data_test_factory(self,
+                                 config: Config,
+                                 query: str,
+                                 expected_length: int,
+                                 gid_assert: Tuple[int, int] | None = None):
+        filter_data(config, query=query, filename=self.filtered_data_file_path)
+        df = pd.read_csv(self.filtered_data_file_path, index_col=0)
+        self.assertEqual(len(df.index), expected_length)
+        if gid_assert:
+            row_idx, expected_gid = gid_assert
+            self.assertEqual(df.iloc[row_idx]['gid'], expected_gid)
+
+    def test_filter_data(self):
         # delete file if persists from previous run
-        if filtered_data_file_path.exists():
-            filtered_data_file_path.unlink()
+        self.delete_filtered_data_file()
 
         config = Config(
-            data_path=Path(__file__).parent / "data", 
+            metadata_file_paths=self.test_data_path, 
             metadata_file_extension="toml", 
-            schema_loc=self.schema_loc
+            schema_loc=self.schema_loc,
+            representation=self.representation
         )
 
-        # test 1
-        filter_data(config, query='df["gid"] >= 66', filename=filtered_data_file_path)
-        df = pd.read_csv(filtered_data_file_path, index_col=0)
-        assert len(df.index) == 2
+        test_params = [
+            ('df["gid"] >= 66', 2, None),
+            ('df["nutrition_subgroup"] == "nachos"', 1, (0, 75)),
+            ('df["quality"] == 1', 0, None)
+        ]
 
-        # test 2
-        filter_data(config, query='df["nutrition_subgroup"] == "nachos"', filename=filtered_data_file_path)        
-        df = pd.read_csv(filtered_data_file_path, index_col=0)
-        assert len(df.index) == 1 and df.iloc[0]['gid'] == 75
-
-        # test 3
-        filter_data(config, query='df["quality"] == 1', filename=filtered_data_file_path)
-        df = pd.read_csv(filtered_data_file_path, index_col=0)
-        assert len(df.index) == 0
+        for query, expected_length, gid_assert in test_params:
+            with self.subTest(query=query):
+                self.filter_data_test_factory(config, query, expected_length, gid_assert)
 
         # delete file if persists before next run
-        if filtered_data_file_path.exists():
-            filtered_data_file_path.unlink()
+        self.delete_filtered_data_file()
 
+    @unittest.skip("Histogram generation does not require testing at this time.")
     def generate_histogram(self):
         pass
 

--- a/test/test_read.py
+++ b/test/test_read.py
@@ -1,6 +1,6 @@
 import unittest
 from pathlib import Path
-from mdframe.reader import run, Config
+from mdframe.reader import run_eager, Config
 import json
 import toml
 
@@ -13,27 +13,27 @@ class TestReader(unittest.TestCase):
     def setUpClass(cls):
         cls.schema_loc = root / "../src/mdframe/schema.json"
 
-    def test_metadata_print(self):
-        data_path = root / "test"
+    def test_metadata_loads(self):
+        data_path = root / "data"
         config = Config(
-            data_path=data_path,
+            metadata_file_paths=data_path,
             metadata_file_extension="toml",
             schema_loc=self.schema_loc
         )
-        df = run(config)
-        print(df)
+        df = run_eager(config)
+        self.assertGreater(len(df), 0)
 
-    def test_metadata_invalid(self):
+    def test_metadata_invalid_raises_decoding_error(self):
         data_path = Path(__file__).parent / "invalid_data"
         config = Config(
-            data_path=data_path,
+            metadata_file_paths=data_path,
             metadata_file_extension="toml",
             schema_loc=self.schema_loc
         )
 
         # expecting this to fail
         with self.assertRaises(toml.decoder.TomlDecodeError):
-            df = run(config)
+            _ = run_eager(config)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I've used `warlock` and replaced most of the prior JSONSchema validation code. `warlock` wraps around JSONSchema and is capable of creating ad-hoc classes and do validation in the background. The internal representation that we will be using can be basically thought of as _a dict with built-in schema validation_.

I want to maintain this representation without flattening things whenever the user wants to use the `run` command from the `reader` module. I have left most of the behavior pertaining to filtering by query unchanged, so they are at the moment Pandas-specific.